### PR TITLE
Release 0.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ fb.find({'a': ANY})          # result: [{'a': 1}, {'a': 2}]
 fb.find({get_a: ANY})        # result: [{'a': 1}, {'a': 2}]
 fb.find(exclude={'a': ANY})  # result: [{}]
 ```
+
+Note that `None` is treated as a normal value and is stored.
 </details>
 
 ### Recipes

--- a/README.md
+++ b/README.md
@@ -169,14 +169,14 @@ ____
 
 ## How it works
 
-For each attribute in the FilterBox, it holds a dict or tree that maps every unique value to the set of objects with 
+For each attribute in the FilterBox, it holds a tree that maps every unique value to the set of objects with 
 that value. 
 
 This is the rough idea of the data structure: 
 ```
 class FilterBox:
     indices = {
-        'attribute1': {val1: set(some_obj_ids), val2: set(other_obj_ids)},
+        'attribute1': BTree({val1: set(some_obj_ids), val2: set(other_obj_ids)}),
         'attribute2': BTree({val3: set(some_obj_ids), val4: set(other_obj_ids)}),
     }
     'obj_map': {obj_ids: objects}
@@ -200,15 +200,5 @@ See the "how it works" pages for more detail:
  - [FilterBox API](https://filterbox.readthedocs.io/en/latest/filterbox.mutable.html#filterbox.mutable.main.FilterBox)
  - [ConcurrentFilterBox API](https://filterbox.readthedocs.io/en/latest/filterbox.concurrent.html#filterbox.concurrent.main.ConcurrentFilterBox)
  - [FrozenFilterBox API](https://filterbox.readthedocs.io/en/latest/filterbox.frozen.html#filterbox.frozen.main.FrozenFilterBox)
-
-### Related projects
-
-FilterBox is a type of inverted index. It is optimized for its goal of finding in-memory Python objects.
-
-Other Python in-memory inverted index implementations are aimed at things like 
-[vector search (rii)](https://pypi.org/project/rii/) and 
-[finding documents by words (lunr)](https://pypi.org/project/lunr/). Outside of Python, ElasticSearch is a popular inverted
-index search tool. Each of these has goals outside of FilterBox's niche; there are no plans to expand FilterBox towards
-these functions.
 
 ____

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 Container for finding Python objects.
 
-Stores objects by attribute value, so finds are very fast. 
-
-[Finding objects using FilterBox can be 5-10x faster than SQLite.](https://github.com/manimino/filterbox/blob/main/examples/perf_demo.ipynb)
+Stores objects by their attribute value. Uses B-tree indexes to make finding very fast.
 
 [![tests Actions Status](https://github.com/manimino/filterbox/workflows/tests/badge.svg)](https://github.com/manimino/filterbox/actions)
 [![Coverage - 100%](https://img.shields.io/static/v1?label=Coverage&message=100%&color=2ea44f)](test/cov.txt)
@@ -39,7 +37,10 @@ fb = FilterBox(               # make a FilterBox
     on=['sky', 'wind_speed']  # attributes to find by
 )
 
-fb.find({'sky': 'sunny', 'wind_speed': {'>=': 5, '<=': 10}})  
+fb.find({
+    'sky': 'sunny', 
+    'wind_speed': {'>=': 5, '<=': 10}
+})  
 # result: [{'day': 'Monday', 'sky': 'sunny', 'wind_speed': 7}]
 ```
 
@@ -54,7 +55,10 @@ def is_palindrome(s):
     return s == s[::-1]
 
 fb = FilterBox(strings, [is_palindrome, len])
-fb.find({is_palindrome: True, len: {'in': [5, 7]}})  
+fb.find({
+    is_palindrome: True, 
+    len: {'in': [5, 7]}
+})
 # result: ['kayak', 'racecar', 'stats']
 ```
 
@@ -172,12 +176,12 @@ ____
 For each attribute in the FilterBox, it holds a tree that maps every unique value to the set of objects with 
 that value. 
 
-This is the rough idea of the data structure: 
+This is a rough idea of the data structure: 
 ```
 class FilterBox:
-    indices = {
-        'attribute1': BTree({val1: set(some_obj_ids), val2: set(other_obj_ids)}),
-        'attribute2': BTree({val3: set(some_obj_ids), val4: set(other_obj_ids)}),
+    indexes = {
+        'attribute1': BTree({10: set(some_obj_ids), 20: set(other_obj_ids)}),
+        'attribute2': BTree({'abc': set(some_obj_ids), 'def': set(other_obj_ids)}),
     }
     'obj_map': {obj_ids: objects}
 }
@@ -201,4 +205,21 @@ See the "how it works" pages for more detail:
  - [ConcurrentFilterBox API](https://filterbox.readthedocs.io/en/latest/filterbox.concurrent.html#filterbox.concurrent.main.ConcurrentFilterBox)
  - [FrozenFilterBox API](https://filterbox.readthedocs.io/en/latest/filterbox.frozen.html#filterbox.frozen.main.FrozenFilterBox)
 
+
+### Why not SQLite?
+
+SQLite is an awesome relational database, and its in-memory storage option allows it to be used as a container for 
+Python objects. [LiteBox](https://github.com/manimino/litebox) is one such implementation.
+
+But `filterbox` was designed only to store and find Python objects quickly. 
+
+As such, filterbox has many advantages over SQLite:
+- The filterbox containers are faster. [Finding objects using filterbox can be 5-10x faster than SQLite.](https://github.com/manimino/filterbox/blob/main/examples/perf_demo.ipynb)
+- They can query any Python data type, not just numbers and strings. While there are tricks to get around this in 
+SQLite, those tricks incur other costs in flexibility, complexity, and/or speed.
+- There is no translation of datatypes, allowing faster finds.
+- They use sparse representations. Objects do not need to fill in "NULL" for missing attributes,
+those attributes are simply not stored.
+- FrozenFilterBox is immutable, and so implements optimizations that are not possible in SQLite.
+- There is less cognitive overhead. You'll never need to VACUUM a FilterBox.
 ____

--- a/dev/btree experiments.ipynb
+++ b/dev/btree experiments.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "We'll use a sorted numpy array and bisection to mimic a tree.\n",
     "- Check what happens when we have unsortable types\n",
-    "- Write a quick bisect implementation that gets array indices etc"
+    "- Write a quick bisect implementation that gets array indexes etc"
    ]
   },
   {

--- a/dev/notes.md
+++ b/dev/notes.md
@@ -28,8 +28,8 @@ which is doable too. Especially if we could remove the hashtable in the process.
 
 Creating a range query thing in numpy:
  - Attempt to sort the values array with `argsort`
- - If that works, sort the values and the indices by the values.
- - Query does `bisect_left()` and `bisect_right()` to get the range of indices for a `<` / `>` query.
+ - If that works, sort the values and the indexes by the values.
+ - Query does `bisect_left()` and `bisect_right()` to get the range of indexes for a `<` / `>` query.
 
 A thought: Is this generally better than what we have? It seems like creating the hash-based arrays
 is more difficult, and while it's versatile, it may not be buying us much. We have to bisect anyway when

--- a/examples/collision.py
+++ b/examples/collision.py
@@ -53,8 +53,8 @@ def main():
         # only search the grid squares near this mouse, and only look at Cats
         nearby_cats = fb.find(
             {
-                grid_x: {"in": [grid_x(m), grid_x(m) - 1, grid_x(m) + 1]},
-                grid_y: {"in": [grid_y(m), grid_y(m) - 1, grid_y(m) + 1]},
+                grid_x: [grid_x(m), grid_x(m) - 1, grid_x(m) + 1],
+                grid_y: [grid_y(m), grid_y(m) - 1, grid_y(m) + 1],
                 get_type: "Cat",
             }
         )

--- a/examples/collision.py
+++ b/examples/collision.py
@@ -45,14 +45,17 @@ def main():
     def grid_y(obj):
         return int(obj.y)
 
-    fb = FilterBox(mice + cats, [grid_x, grid_y, type])
+    def get_type(obj):
+        return type(obj).__name__
+
+    fb = FilterBox(mice + cats, [grid_x, grid_y, get_type])
     for m in mice:
         # only search the grid squares near this mouse, and only look at Cats
         nearby_cats = fb.find(
             {
-                grid_x: [grid_x(m), grid_x(m) - 1, grid_x(m) + 1],
-                grid_y: [grid_y(m), grid_y(m) - 1, grid_y(m) + 1],
-                type: Cat,
+                grid_x: {"in": [grid_x(m), grid_x(m) - 1, grid_x(m) + 1]},
+                grid_y: {"in": [grid_y(m), grid_y(m) - 1, grid_y(m) + 1]},
+                get_type: "Cat",
             }
         )
         for c in nearby_cats:

--- a/filterbox/btree.py
+++ b/filterbox/btree.py
@@ -1,6 +1,6 @@
 from BTrees.OOBTree import OOBTree
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
 
 class BTree:
@@ -26,32 +26,8 @@ class BTree:
             self.tree = OOBTree()
             self.length = 0
 
-    def get_range_expr(self, expr: Dict[str, Any]):
-        """
-        Calls self.get_range() with appropriate arguments based on the operations in expr.
-        e.g., translates {'<': 3} into get_values(3, None, True, False).
-        Will ignore keys in expr other than '<', '<=', '>', '>='.
-        """
-        if "<" in expr and "<=" in expr:
-            raise ValueError('Expression should only have one of "<", "<=" operators.')
-        if ">" in expr and ">=" in expr:
-            raise ValueError('Expression should only have one of ">", ">=" operators.')
-        min_key = None
-        max_key = None
-        include_min = True
-        include_max = True
-        if ">" in expr:
-            min_key = expr[">"]
-            include_min = False
-        if ">=" in expr:
-            min_key = expr[">="]
-            include_min = True
-        if "<" in expr:
-            max_key = expr["<"]
-            include_max = False
-        if "<=" in expr:
-            max_key = expr["<="]
-            include_max = True
+    def get_range_expr(self, expr: Dict[str, Any]) -> List:
+        min_key, max_key, include_min, include_max = range_expr_to_args(expr)
         return self.get_range(min_key, max_key, include_min, include_max)
 
     def get_range(
@@ -133,3 +109,28 @@ class BTree:
 
     def __contains__(self, item):
         return item in self.tree
+
+
+def range_expr_to_args(expr: Dict[str, Any]) -> Tuple[Any, Any, bool, bool]:
+    """
+    Turn a range expr into (min_key, max_key, include_min, include_max), which are easier to use with BTrees.
+    e.g., translates {'<': 3} into get_values(3, None, True, False).
+    Will ignore keys in expr other than '<', '<=', '>', '>='.
+    """
+    min_key = None
+    max_key = None
+    include_min = True
+    include_max = True
+    if ">" in expr:
+        min_key = expr[">"]
+        include_min = False
+    if ">=" in expr:
+        min_key = expr[">="]
+        include_min = True
+    if "<" in expr:
+        max_key = expr["<"]
+        include_max = False
+    if "<=" in expr:
+        max_key = expr["<="]
+        include_max = True
+    return min_key, max_key, include_min, include_max

--- a/filterbox/concurrent/main.py
+++ b/filterbox/concurrent/main.py
@@ -37,7 +37,7 @@ class ConcurrentFilterBox:
             self.lock = RWLockFair()
         else:
             raise ValueError(f"priority must be {READERS}, {WRITERS}, or {FAIR}.")
-        self._indices = self.box._indices  # only used during testing
+        self._indexes = self.box._indexes  # only used during testing
 
     @contextmanager
     def read_lock(self):

--- a/filterbox/constants.py
+++ b/filterbox/constants.py
@@ -40,6 +40,7 @@ VALID_OPERATORS = [
     "ge",
 ]
 OPERATOR_MAP = {
+    "eq": "==",
     "lt": "<",
     "le": "<=",  # Python style <=
     "lte": "<=",  # ElasticSearch style <=

--- a/filterbox/constants.py
+++ b/filterbox/constants.py
@@ -25,7 +25,20 @@ when it's literally this object. set() is a simple object that satisfies this pr
 """
 ANY = MatchAnything()
 
-VALID_OPERATORS = ["in", "<", "<=", ">", ">=", "lt", "lte", "le", "gt", "gte", "ge"]
+VALID_OPERATORS = [
+    "==",
+    "in",
+    "<",
+    "<=",
+    ">",
+    ">=",
+    "lt",
+    "lte",
+    "le",
+    "gt",
+    "gte",
+    "ge",
+]
 OPERATOR_MAP = {
     "lt": "<",
     "le": "<=",  # Python style <=

--- a/filterbox/frozen/froz_attr_val.py
+++ b/filterbox/frozen/froz_attr_val.py
@@ -9,7 +9,7 @@ from bisect import bisect_left, bisect_right
 from typing import Union, Callable, Set
 
 from filterbox.btree import BTree
-from filterbox.constants import SIZE_THRESH
+from filterbox.constants import ANY, SIZE_THRESH
 from filterbox.utils import make_empty_array
 from filterbox.init_helpers import get_vals, run_length_encode
 
@@ -73,6 +73,8 @@ class FrozenAttrValIndex:
 
     def get(self, val) -> np.ndarray:
         """Get indexes of objects whose attribute is val."""
+        if val is ANY:
+            return self.get_all()
         if val is None:
             return self.none_ids
         if val in self.val_to_obj_ids:

--- a/filterbox/frozen/froz_attr_val.py
+++ b/filterbox/frozen/froz_attr_val.py
@@ -18,8 +18,8 @@ class FrozenAttrValIndex:
     """
     Stores data and handles requests that are relevant to a single attribute of a FrozenFilterBox.
 
-    There are three places where object indices are stored.
-     - none_ids stores all indices for with the attribute value None
+    There are three places where object indexes are stored.
+     - none_ids stores all indexes for with the attribute value None
      - val_to_obj_ids stores object ids for attribute values that have many objects
      - val_arr + obj_id_arr store all the rest.
     """
@@ -32,7 +32,7 @@ class FrozenAttrValIndex:
         # Nones get stored in their own special spot so they don't break sortability.
         self.none_ids = make_empty_array(self.dtype)
 
-        # We will pull repeated attributes out into a BTree and pre-sort their indices.
+        # We will pull repeated attributes out into a BTree and pre-sort their indexes.
         # Saves memory, and makes object lookups *way* faster.
         self.val_to_obj_ids = BTree()
 
@@ -72,7 +72,7 @@ class FrozenAttrValIndex:
         self.obj_id_arr = obj_id_arr[unused]
 
     def get(self, val) -> np.ndarray:
-        """Get indices of objects whose attribute is val."""
+        """Get indexes of objects whose attribute is val."""
         if val is None:
             return self.none_ids
         if val in self.val_to_obj_ids:
@@ -85,7 +85,7 @@ class FrozenAttrValIndex:
         return np.sort(self.obj_id_arr[left:right])
 
     def get_all(self) -> np.ndarray:
-        """Get indices of every object with this attribute. Used when matching ANY."""
+        """Get indexes of every object with this attribute. Used when matching ANY."""
         arrs = [self.obj_id_arr]
         for v in self.val_to_obj_ids.values():
             arrs.append(v)

--- a/filterbox/frozen/how_it_works.md
+++ b/filterbox/frozen/how_it_works.md
@@ -15,7 +15,7 @@ Pseudocode:
 ```
 class FrozenFilterBox:
     # holds each attribute index and an array of objects
-    indices = {
+    indexes = {
         'attr1': FrozenAttrIndex(),
         'attr2': FrozenAttrIndex()
     }
@@ -23,20 +23,20 @@ class FrozenFilterBox:
 }
 
 class MutableAttrIndex: 
-    # maps the values for an attribute to object array indices
+    # maps the values for an attribute to object array indexes
     
     val_arr = np.array(attribute value for each object)  # sorted by value
     obj_idx_arr = np.array(index in obj array for each object)  # sorted by value
     
     # tree stores values for which there are many matching objects
     tree = BTree({
-        val1: np.array(sorted_obj_arr_indices),
-        val2: np.array(sorted_obj_arr_indices)
+        val1: np.array(sorted_obj_arr_indexes),
+        val2: np.array(sorted_obj_arr_indexes)
     })
 ```
 
 Rather than having a dict lookup for object id -> object, we just store the objects in an array. Instead of
-object IDs, we can use indices into that array. Handily, the indices can be `int32` if there are less than a few
+object IDs, we can use indexes into that array. Handily, the indexes can be `int32` if there are less than a few
 billion objects, which is usually the case. `int32` operations are a little faster than `int64`, in addition to being 
 more RAM-efficient.
 
@@ -55,8 +55,8 @@ What is their intersection? Do you need to convert them to `set` to figure it ou
 Of course not -- sorted array intersection is easy. There's a great package called 
 [sortednp](https://pypi.org/project/sortednp/) that implements fast set operations on sorted numpy arrays.
 
-So once we have the object indices for each part of a query, `sortednp.intersect` and friends will get us the final
-object indices.
+So once we have the object indexes for each part of a query, `sortednp.intersect` and friends will get us the final
+object indexes.
 
 ### Wrap up
 

--- a/filterbox/frozen/how_it_works.md
+++ b/filterbox/frozen/how_it_works.md
@@ -1,58 +1,40 @@
 ## How It Works, Frozen Edition
 
-**Note: This assumes familiarity with the regular FilterBox.**
 
-### Implementing dict-of-set using Numpy arrays
+### Implementing BTree-of-set using Numpy arrays
 
 In FrozenFilterBox, we know that:
  - The data will never change
  - The values are always integers
 
-So rather than using a Python `dict of set of object IDs` like FilterBox does, FrozenFilterBox uses numpy arrays to 
-achieve the same thing. This design is much faster and far more memory-efficient.
+This means we can use an array-based implementation rather than a tree. This design is much faster and far more 
+memory-efficient. Bisecting a sorted array allows O(log(n)) lookup, just like a tree, while not incurring the various
+overheads that a tree does. 
 
-Let's look at the structure of a "dict of set as arrays" implementation.
-
-Suppose we have keys A, B, C, and D. 
- - A hashes to 1
- - B hashes to 2
- - C and D both hash to 3
-
-So we have the arrays:
+Pseudocode:
 ```
-keys    = [A, B, B, D, D, C, C, C]  # keys sorted by hash and grouped by key
-hashes  = [1, 2, 2, 3, 3, 3, 3, 3]  # sorted by hash
-obj_ids = [z, h, x, y, n, m, q, r]  # object IDs that we will look up by key
+class FrozenFilterBox:
+    # holds each attribute index and an array of objects
+    indices = {
+        'attr1': FrozenAttrIndex(),
+        'attr2': FrozenAttrIndex()
+    }
+    'objects': np.array(dtype="O")  
+}
 
-# compute these by run-length-encoding of the hashes array
-unique_hashes   = [1, 2, 3]
-hash_start_pos  = [0, 1, 3]
-hash_run_length = [1, 2, 5]
+class MutableAttrIndex: 
+    # maps the values for an attribute to object array indices
+    
+    val_arr = np.array(attribute value for each object)  # sorted by value
+    obj_idx_arr = np.array(index in obj array for each object)  # sorted by value
+    
+    # tree stores values for which there are many matching objects
+    tree = BTree({
+        val1: np.array(sorted_obj_arr_indices),
+        val2: np.array(sorted_obj_arr_indices)
+    })
 ```
 
-Now let's find the object IDs that match the key B.
- - Hash B to 2
- - Find that 2 is in unique_hashes (it's a sorted array, so this takes log(n))
- - Find start and end positions using hash_start_pos and hash_run_length.
- - hash_start_pos = 1 and hash_run_length = 2, so we'll check keys at positions 1 and 2.
- - The keys at positions 1 and 2 are both B. Get their obj_ids.
- - Return object IDs `[h, x]`.
-
-What if we wanted the object ID for key C? It has the same hash as D does -- how will that work?
- - Hash C to 2
- - Find that C is in unique_hashes (it's a sorted array, so this takes log(n))
- - Find start and end positions using hash_start_pos and hash_run_length.
- - hash_start_pos = 3 and hash_run_length = 5, so we'll check keys in the range (3, 3+5).
- - Initialize a pointer at 3 and a pointer at 8. Move them towards each other, stopping on the first C.
- - Keys 5, 6, and 7 are all C.
- - Return object IDs `[m, q, r]`.
-
-Note that we never sort by value here. There's a good reason for it; the values may not be comparable.
-Maybe A is a string, B is an int, and C is a tuple. Each is hashable, but defining a `<` on them wouldn't make sense.
-That's part of the fun of making a container in Python - you never know what types you're going to get!
-
-Note also that we didn't use the `hashes` array during lookup. It is not actually stored, it's just shown in
-this example for clarity.
 
 ### Set operations on numpy arrays
 

--- a/filterbox/frozen/how_it_works.md
+++ b/filterbox/frozen/how_it_works.md
@@ -35,6 +35,11 @@ class MutableAttrIndex:
     })
 ```
 
+Rather than having a dict lookup for object id -> object, we just store the objects in an array. Instead of
+object IDs, we can use indices into that array. Handily, the indices can be `int32` if there are less than a few
+billion objects, which is usually the case. `int32` operations are a little faster than `int64`, in addition to being 
+more RAM-efficient.
+
 
 ### Set operations on numpy arrays
 
@@ -48,13 +53,10 @@ If you have the arrays:
 What is their intersection? Do you need to convert them to `set` to figure it out? 
 
 Of course not -- sorted array intersection is easy. There's a great package called 
-[sortednp](https://pypi.org/project/sortednp/) that implements fast operations on sorted numpy arrays.
+[sortednp](https://pypi.org/project/sortednp/) that implements fast set operations on sorted numpy arrays.
 
-So once we have the object IDs for each part of a query, `sortednp.intersect` and friends will get us the final
-ID set.
-
-Since we're using parallel numpy arrays, the object IDs are not from Python `id()` here; they are actually just
-indices into a numpy array of objects stored in FrozenFilterBox. 
+So once we have the object indices for each part of a query, `sortednp.intersect` and friends will get us the final
+object indices.
 
 ### Wrap up
 

--- a/filterbox/frozen/utils.py
+++ b/filterbox/frozen/utils.py
@@ -3,9 +3,9 @@ import sortednp as snp
 
 
 def snp_difference(left: np.ndarray, right: np.ndarray):
-    # difference = left - indices_in_intersection(left, right)
-    _, indices = snp.intersect(left, right, indices=True)
-    indices_to_discard = indices[0]
+    # difference = left - indexes_in_intersection(left, right)
+    _, indexes = snp.intersect(left, right, indices=True)
+    indexes_to_discard = indexes[0]
     keep_these = np.ones_like(left, dtype=bool)
-    keep_these[indices_to_discard] = False
+    keep_these[indexes_to_discard] = False
     return left[keep_these]

--- a/filterbox/mutable/how_it_works.md
+++ b/filterbox/mutable/how_it_works.md
@@ -5,7 +5,7 @@ Here's more detailed pseudocode of a FilterBox:
 ```
 class FilterBox:
     # holds each attribute index and the id-to-object map
-    indices = {
+    indexes = {
         'attr1': MutableAttrIndex(),
         'attr2': MutableAttrIndex()
     }

--- a/filterbox/mutable/how_it_works.md
+++ b/filterbox/mutable/how_it_works.md
@@ -3,9 +3,6 @@
 Here's more detailed pseudocode of a FilterBox:
 
 ```
-# Object IDs are stored in Int64-typed sets, which are more memory-efficient than Python set()
-from cykhash import Int64Set
-
 class FilterBox:
     # holds each attribute index and the id-to-object map
     indices = {
@@ -18,10 +15,10 @@ class FilterBox:
 
 class MutableAttrIndex: 
     # maps the values for one attribute to object IDs
-    vals_to_ids = {
-        val1: Int64Set(some_obj_ids), 
-        val2: Int64Set(other_obj_ids)
-    }
+    tree = BTree({
+        val1: set(some_obj_ids), 
+        val2: set(other_obj_ids)
+    })
 ```
 
 On `FilterBox.find()`:
@@ -57,7 +54,7 @@ Results:
 That table tells us a story:
  - Small collections of any type are extremely inefficient. Don't make collections of size 1.
  - Immutable collections are cheaper. Tuples, arrays, and numpy arrays cost less memory than the set types.
- - Typed collections are cheaper. Numpy arrays and cykhash Int64Sets are cheaper than tuples or Python sets.
+ - Typed collections are cheaper. Numpy arrays and [cykhash](https://github.com/realead/cykhash) Int64Sets are cheaper than tuples or Python sets.
 
 The best collection in terms of memory usage is a big array. But FilterBox is mutable; we need to add and remove
 objects in a few microseconds. Rewriting a big array on change is too slow. So we'll save the arrays for 

--- a/filterbox/mutable/main.py
+++ b/filterbox/mutable/main.py
@@ -170,15 +170,15 @@ class FilterBox:
         """Look at an attr, handle its expr appropriately"""
         matches = None
         # handle 'in' and '=='
-        eq_expr = {
-            op: val for op, val in expr.items() if op in ["==", "in"]
-        }
+        eq_expr = {op: val for op, val in expr.items() if op in ["==", "in"]}
         for op, val in eq_expr.items():
             if op == "==":
                 op_matches = self._indexes[attr].get_obj_ids(val)
             elif op == "in":
                 op_matches = self._match_any_value_in(attr, expr["in"])
-            matches = op_matches if matches is None else cyk_intersect(op_matches, matches)
+            matches = (
+                op_matches if matches is None else cyk_intersect(op_matches, matches)
+            )
 
         # handle range query
         range_expr = {
@@ -186,7 +186,11 @@ class FilterBox:
         }
         if range_expr:
             range_matches = self._indexes[attr].get_ids_by_range(range_expr)
-            matches = range_matches if matches is None else cyk_intersect(range_matches, matches)
+            matches = (
+                range_matches
+                if matches is None
+                else cyk_intersect(range_matches, matches)
+            )
         return matches
 
     def _match_any_value_in(
@@ -194,7 +198,6 @@ class FilterBox:
     ) -> Int64Set:
         """Handle 'in' queries. Return the union of object ID matches for the values."""
         matches = Int64Set()
-        print(values)
         for v in values:
             v_matches = self._indexes[attr].get_obj_ids(v)
             matches = cyk_union(matches, v_matches)
@@ -213,10 +216,6 @@ class FilterBox:
             return list(
                 itemgetter(*obj_ids)(self.obj_map)
             )  # itemgetter returns a tuple of items here, so make it a list
-
-    def __getitem__(self, item):
-        """Shorthand for find(match=item)."""
-        return self.find(item)
 
     def __contains__(self, obj: Any):
         return id(obj) in self.obj_map

--- a/filterbox/mutable/main.py
+++ b/filterbox/mutable/main.py
@@ -3,13 +3,7 @@ from typing import Optional, List, Any, Dict, Callable, Union, Iterable, Set
 
 from cykhash import Int64Set
 
-from filterbox import ANY
-from filterbox.utils import (
-    cyk_intersect,
-    cyk_union,
-    validate_query,
-    fix_operators,
-)
+from filterbox.utils import cyk_intersect, cyk_union, standardize_expr, validate_query
 from filterbox.mutable.mutable_attr import MutableAttrIndex
 
 
@@ -18,8 +12,7 @@ class FilterBox:
     Create a FilterBox containing the ``objs``, queryable by the ``on`` attributes.
 
     Args:
-        objs: The objects that FilterBox will contain initially.
-            Objects do not need to be hashable, any object works.
+        objs: The objects that FilterBox will contain initially. Optional.
 
         on: The attributes that will be used for finding objects.
             Must contain at least one.
@@ -27,7 +20,9 @@ class FilterBox:
     It's OK if the objects in ``objs`` are missing some or all of the attributes in ``on``. They will still be
     stored, and can found with ``find()``.
 
-    For the objects that do contain the ``on`` attributes, those attribute values must be hashable.
+    For the objects that do contain the attributes on ``on``, those attribute values must be hashable and sortable.
+    Most Python objects are hashable. Implement the function ``__lt__(self, other)`` to make a class sortable.
+    An attribute value of ``None`` is acceptable as well, even though None is not sortable.
     """
 
     def __init__(
@@ -46,9 +41,9 @@ class FilterBox:
             self.obj_map = dict()
 
         # Build an index for each attribute
-        self._indices = {}
+        self._indexes = {}
         for attr in on:
-            self._indices[attr] = MutableAttrIndex(attr, self.obj_map, objs)
+            self._indexes[attr] = MutableAttrIndex(attr, objs)
 
     def find(
         self,
@@ -58,53 +53,83 @@ class FilterBox:
         """Find objects in the FilterBox that satisfy the match and exclude constraints.
 
         Args:
-            match: Dict of ``{attribute: value}`` defining the subset of objects that match.
+            match: Dict of ``{attribute: expression}`` defining the subset of objects that match.
                 If ``None``, all objects will match.
 
                 Each attribute is a string or Callable. Must be one of the attributes specified in the constructor.
 
-                Value can be any of the following:
-                 - A single hashable value, which will match all objects with that value for the attribute.
-                 - A dict specifying operators and values, such as ``{'>' 3}`` or ``{'in': [1, 2, 3]}``.
-                 - ``filterbox.ANY``, which matches all objects having the attribute.
+                The expression can be any of the following:
+                 - A dict of ``{operator: value}``, such as ``{'==': 1}`` ``{'>': 5}``, or ``{'in': [1, 2, 3]}``.
+                 - A single value, which is a shorthand for `{'==': value}`.
+                 - A list of values, which is a shorthand for ``{'in': [list_of_values]}``.
 
-                 Valid operators are 'in', '<', '<=', '>', '>=', 'lt', 'le', 'lte', 'gt', 'ge', and 'gte'.
+                 The special value ``filterbox.ANY`` will match all objects having the attribute.
 
-            exclude: Dict of ``{attribute: value}`` defining the subset of objects that do not match.
+                 Valid operators are '==' 'in', '<', '<=', '>', '>='.
+                 The aliases 'eq' 'lt', 'le', 'lte', 'gt', 'ge', and 'gte' work too.
+                 To match a None value, use ``{'==': None}``. There is no separate operator for None values.
+
+            exclude: Dict of ``{attribute: expression}`` defining the subset of objects that do not match.
                 If ``None``, no objects will be excluded.
 
                 Each attribute is a string or Callable. Must be one of the attributes specified in the constructor.
-
-                Value can be any of the following:
-                 - A single hashable value, which will exclude all objects with that value for the attribute.
-                 - A dict specifying operators and values to exclude, such as ``{'>' 3}`` or ``{'in': [1, 2, 3]}``
-                 - ``filterbox.ANY``, which excludes all objects having the attribute.
+                Valid expressions are the same as in ``match``.
 
         Returns:
-            List of objects matching the constraints.
+            List of objects matching the constraints. List will be unordered.
         """
-        hits = self._find_ids(match, exclude)
+        # validate input and convert expressions to dict
+        validate_query(self._indexes, match, exclude)
+        for arg in [match, exclude]:
+            if arg:
+                for key in arg:
+                    arg[key] = standardize_expr(arg[key])
 
-        # itemgetter is about 10% faster than doing a comprehension like [self.objs[ptr] for ptr in hits]
-        if len(hits) == 0:
-            return []
-        elif len(hits) == 1:
-            return [
-                itemgetter(*hits)(self.obj_map)
-            ]  # itemgetter returns a single item here, not in a collection
-        else:
-            return list(
-                itemgetter(*hits)(self.obj_map)
-            )  # itemgetter returns a tuple of items here, so make it a list
+        obj_ids = self._find_ids(match, exclude)
+        return self._obj_ids_to_objs(obj_ids)
+
+    def add(self, obj: Any):
+        """Add the object, evaluating any attributes and storing the results.
+        If the object is already present, it will not be updated."""
+        ptr = id(obj)
+        if ptr in self.obj_map:
+            return
+        self.obj_map[ptr] = obj
+        for attr in self._indexes:
+            self._indexes[attr].add(ptr, obj)
+
+    def remove(self, obj: Any):
+        """Remove the object. Raises KeyError if not present."""
+        ptr = id(obj)
+        if ptr not in self.obj_map:
+            raise KeyError
+
+        for attr in self._indexes:
+            self._indexes[attr].remove(ptr, obj)
+        del self.obj_map[ptr]
+
+    def update(self, obj: Any):
+        """Remove and re-add the object, updating all stored attributes. Raises KeyError if object not present."""
+        self.remove(obj)
+        self.add(obj)
+
+    def get_values(self, attr: Union[str, Callable]) -> Set:
+        """Get the unique values we have for the given attribute. Useful for deciding what to ``find()`` on.
+
+        Args:
+            attr: The attribute to get values for.
+
+        Returns:
+            Set of all unique values for this attribute.
+        """
+        return self._indexes[attr].get_values()
 
     def _find_ids(
         self,
-        match: Optional[Dict[Union[str, Callable], Any]] = None,
-        exclude: Optional[Dict[Union[str, Callable], Any]] = None,
+        match: Optional[Dict[Union[str, Callable], Dict]] = None,
+        exclude: Optional[Dict[Union[str, Callable], Dict]] = None,
     ) -> Int64Set:
         """Perform lookup based on given constraints. Return a set of object IDs."""
-        validate_query(self._indices, match, exclude)
-
         # perform 'match' query
         if match:
             # find intersection of each attr
@@ -139,80 +164,59 @@ class FilterBox:
 
         return hits
 
-    def add(self, obj: Any):
-        """Add the object, evaluating any attributes and storing the results.
-        If the object is already present, it will not be updated."""
-        ptr = id(obj)
-        if ptr in self.obj_map:
-            return
-        self.obj_map[ptr] = obj
-        for attr in self._indices:
-            self._indices[attr].add(ptr, obj)
-
-    def remove(self, obj: Any):
-        """Remove the object. Raises KeyError if not present."""
-        ptr = id(obj)
-        if ptr not in self.obj_map:
-            raise KeyError
-
-        for attr in self._indices:
-            self._indices[attr].remove(ptr, obj)
-        del self.obj_map[ptr]
-
-    def update(self, obj: Any):
-        """Remove and re-add the object, updating all stored attributes. Raises KeyError if object not present."""
-        self.remove(obj)
-        self.add(obj)
-
-    def get_values(self, attr: Union[str, Callable]) -> Set:
-        """Get the unique values we have for the given attribute. Useful for deciding what to ``find()`` on.
-
-        Args:
-            attr: The attribute to get values for.
-
-        Returns:
-            Set of all unique values for this attribute.
-        """
-        return self._indices[attr].get_values()
-
-    def _match_attr_expr(self, attr, expr) -> Int64Set:
+    def _match_attr_expr(
+        self, attr: Union[str, Callable], expr: Dict[str, Any]
+    ) -> Int64Set:
         """Look at an attr, handle its expr appropriately"""
+        matches = None
+        # handle 'in' and '=='
+        eq_expr = {
+            op: val for op, val in expr.items() if op in ["==", "in"]
+        }
+        for op, val in eq_expr.items():
+            if op == "==":
+                op_matches = self._indexes[attr].get_obj_ids(val)
+            elif op == "in":
+                op_matches = self._match_any_value_in(attr, expr["in"])
+            matches = op_matches if matches is None else cyk_intersect(op_matches, matches)
 
-        if isinstance(expr, dict):
-            fix_operators(expr)
-            matches = None
-            if "in" in expr:
-                # always do 'in' first -- it doesn't require get_values() which can be slow.
-                matches = self._match_any_value_in(attr, expr["in"])
-                del expr["in"]
-            if expr:
-                # handle <, >, etc
-                expr_matches = self._indices[attr].get_ids_by_range(expr)
-                if matches is None:
-                    matches = expr_matches
-                else:
-                    matches = matches.intersection(expr_matches)
-            return matches
-        elif expr is ANY:
-            return self._indices[attr].get_all_ids()
-        elif isinstance(expr, set):
-            raise ValueError(
-                f"Expression {expr} is a set. Did you mean to make a dict?"
-            )
-        else:
-            # match this specific value
-            return self._indices[attr].get_obj_ids(expr)
+        # handle range query
+        range_expr = {
+            op: val for op, val in expr.items() if op in ["<", ">", "<=", ">="]
+        }
+        if range_expr:
+            range_matches = self._indexes[attr].get_ids_by_range(range_expr)
+            matches = range_matches if matches is None else cyk_intersect(range_matches, matches)
+        return matches
 
     def _match_any_value_in(
         self, attr: Union[str, Callable], values: Iterable[Any]
     ) -> Int64Set:
-        """Get the union of object ID matches for the values."""
-        # Note: this could also be done with list operations, but union() is slightly faster in most cases.
+        """Handle 'in' queries. Return the union of object ID matches for the values."""
         matches = Int64Set()
+        print(values)
         for v in values:
-            v_matches = self._indices[attr].get_obj_ids(v)
+            v_matches = self._indexes[attr].get_obj_ids(v)
             matches = cyk_union(matches, v_matches)
         return Int64Set(matches)
+
+    def _obj_ids_to_objs(self, obj_ids: Int64Set) -> List[Any]:
+        """Look up each obj_id in self.obj_map, and return the list of objs."""
+        # Using itemgetter is about 10% faster than doing a comprehension like [self.objs[ptr] for ptr in hits]
+        if len(obj_ids) == 0:
+            return []
+        elif len(obj_ids) == 1:
+            return [
+                itemgetter(*obj_ids)(self.obj_map)
+            ]  # itemgetter returns a single item here, not in a collection
+        else:
+            return list(
+                itemgetter(*obj_ids)(self.obj_map)
+            )  # itemgetter returns a tuple of items here, so make it a list
+
+    def __getitem__(self, item):
+        """Shorthand for find(match=item)."""
+        return self.find(item)
 
     def __contains__(self, obj: Any):
         return id(obj) in self.obj_map

--- a/filterbox/mutable/mutable_attr.py
+++ b/filterbox/mutable/mutable_attr.py
@@ -3,7 +3,7 @@ from typing import Callable, Union, Dict, Any, Iterable, Optional, Hashable, Set
 
 from cykhash import Int64Set
 
-from filterbox.constants import ARR_TYPE, ARRAY_SIZE_MAX, SET_SIZE_MIN
+from filterbox.constants import ANY, ARR_TYPE, ARRAY_SIZE_MAX, SET_SIZE_MIN
 from filterbox.utils import get_attribute
 from filterbox.btree import BTree
 
@@ -14,15 +14,11 @@ class MutableAttrIndex:
     def __init__(
         self,
         attr: Union[Callable, str],
-        obj_map: Dict[int, Any],
         objs: Optional[Iterable[Any]] = None,
     ):
         self.attr = attr
-        self.obj_map = obj_map
-        self.none_ids = (
-            Int64Set()
-        )  # Special storage for object IDs with the attribute value None
-        self.tree = BTree()
+        self.none_ids = Int64Set()  # Stores object IDs for the attribute value None
+        self.tree = BTree()  # Stores object IDs for all other values
         self.n_obj_ids = 0
         if objs:
             for obj in objs:
@@ -33,14 +29,64 @@ class MutableAttrIndex:
         val, success = get_attribute(obj, self.attr)
         if not success:
             return
-        if val is None:
-            self.none_ids.add(ptr)
-            return
         self._add_val(ptr, val)
         self.n_obj_ids += 1
 
+    def get_obj_ids(self, val: Any) -> Int64Set:
+        """Get the object IDs associated with this value as an Int64Set."""
+        if val is ANY:
+            return self.get_all_ids()
+        if val is None:
+            return self.none_ids
+        ids = self.tree.get(val, Int64Set())
+        if type(ids) is array:
+            return Int64Set(ids)
+        elif type(ids) is Int64Set:
+            return ids
+        else:
+            return Int64Set([ids])
+
+    def remove(self, ptr: int, obj: Any):
+        """Remove a single object from the index. ptr is already known to be in the FilterBox.
+        Runs in O(1) if obj has this attr and the value of the attr hasn't changed. O(n_keys) otherwise."""
+        removed = False
+        val, success = get_attribute(obj, self.attr)
+        if success:
+            removed = self._try_remove(ptr, val)
+        if not removed:
+            # do O(n) search
+            for val in list(self.tree.keys()):
+                removed = self._try_remove(ptr, val)
+                if removed:
+                    break
+
+    def get_all_ids(self) -> Int64Set:
+        """Get the ID of every object that has this attribute.
+        Called when matching or excluding ``{attr: hashindex.ANY}``."""
+        obj_ids = Int64Set(self.none_ids)
+        for key, val in self.tree.items():
+            self._add_val_to_set(val, obj_ids)
+        return obj_ids
+
+    def get_values(self) -> Set:
+        """Get unique values we have objects for."""
+        vals = set(self.tree.keys())
+        if len(self.none_ids):
+            vals.add(None)
+        return vals
+
+    def get_ids_by_range(self, expr: Dict[str, Any]):
+        """Get object IDs based on less than / greater than some value"""
+        obj_ids = Int64Set()
+        vals = self.tree.get_range_expr(expr)
+        for val in vals:
+            self._add_val_to_set(val, obj_ids)
+        return obj_ids
+
     def _add_val(self, ptr, val):
-        if val in self.tree:
+        if val is None:
+            self.none_ids.add(ptr)
+        elif val in self.tree:
             obj_ids = self.tree[val]
             if type(obj_ids) is Int64Set:
                 self.tree[val].add(ptr)
@@ -58,18 +104,6 @@ class MutableAttrIndex:
         else:
             # new val, add the int
             self.tree[val] = ptr
-
-    def get_obj_ids(self, val: Any) -> Int64Set:
-        """Get the object IDs associated with this value as an Int64Set."""
-        if val is None:
-            return self.none_ids
-        ids = self.tree.get(val, Int64Set())
-        if type(ids) is array:
-            return Int64Set(ids)
-        elif type(ids) is Int64Set:
-            return ids
-        else:
-            return Int64Set([ids])
 
     @staticmethod
     def _add_val_to_set(val: Any, obj_ids: Int64Set):
@@ -115,43 +149,6 @@ class MutableAttrIndex:
             del self.tree[val]
         self.n_obj_ids -= 1
         return True
-
-    def remove(self, ptr: int, obj: Any):
-        """Remove a single object from the index. ptr is already known to be in the FilterBox.
-        Runs in O(1) if obj has this attr and the value of the attr hasn't changed. O(n_keys) otherwise."""
-        removed = False
-        val, success = get_attribute(obj, self.attr)
-        if success:
-            removed = self._try_remove(ptr, val)
-        if not removed:
-            # do O(n) search
-            for val in list(self.tree.keys()):
-                removed = self._try_remove(ptr, val)
-                if removed:
-                    break
-
-    def get_all_ids(self) -> Int64Set:
-        """Get the ID of every object that has this attribute.
-        Called when matching or excluding ``{attr: hashindex.ANY}``."""
-        obj_ids = Int64Set(self.none_ids)
-        for key, val in self.tree.items():
-            self._add_val_to_set(val, obj_ids)
-        return obj_ids
-
-    def get_values(self) -> Set:
-        """Get unique values we have objects for."""
-        vals = set(self.tree.keys())
-        if len(self.none_ids):
-            vals.add(None)
-        return vals
-
-    def get_ids_by_range(self, expr: Dict[str, Any]):
-        """Get object IDs based on less than / greater than some value"""
-        obj_ids = Int64Set()
-        vals = self.tree.get_range_expr(expr)
-        for val in vals:
-            self._add_val_to_set(val, obj_ids)
-        return obj_ids
 
     def __len__(self):
         return self.n_obj_ids

--- a/filterbox/mutable/mutable_attr.py
+++ b/filterbox/mutable/mutable_attr.py
@@ -12,9 +12,7 @@ class MutableAttrIndex:
     """Stores data and handles requests that are relevant to a single attribute of a FilterBox."""
 
     def __init__(
-        self,
-        attr: Union[Callable, str],
-        objs: Optional[Iterable[Any]] = None,
+        self, attr: Union[Callable, str], objs: Optional[Iterable[Any]] = None,
     ):
         self.attr = attr
         self.none_ids = Int64Set()  # Stores object IDs for the attribute value None

--- a/filterbox/utils.py
+++ b/filterbox/utils.py
@@ -40,9 +40,7 @@ def standardize_expr(expr: Any) -> Dict:
     if isinstance(expr, list):
         return {"in": expr}
     if isinstance(expr, set) and expr is not ANY:
-        raise ValueError(
-            f"Expression {expr} is a set. Did you mean to make a dict?"
-        )
+        raise ValueError(f"Expression {expr} is a set. Did you mean to make a dict?")
     # otherwise, it's a value
     return {"==": expr}
 

--- a/filterbox/utils.py
+++ b/filterbox/utils.py
@@ -1,10 +1,10 @@
 import numpy as np
 
-from typing import List, Union, Callable, Optional, Any, Dict, Tuple, Set
+from typing import List, Union, Callable, Optional, Any, Dict, Tuple
 
 from cykhash import Int64Set
 
-from filterbox.constants import VALID_OPERATORS, OPERATOR_MAP
+from filterbox.constants import ANY, VALID_OPERATORS, OPERATOR_MAP
 from filterbox.exceptions import AttributeNotFoundError, MissingAttribute
 
 
@@ -33,8 +33,41 @@ def get_attributes(cls) -> List[str]:
     return list(cls.__annotations__.keys())
 
 
+def standardize_expr(expr: Any) -> Dict:
+    """Turn a find() expr into a dict of {operator: value}."""
+    if isinstance(expr, dict):
+        return validate_and_standardize_operators(expr)
+    if isinstance(expr, list):
+        return {"in": expr}
+    if isinstance(expr, set) and expr is not ANY:
+        raise ValueError(
+            f"Expression {expr} is a set. Did you mean to make a dict?"
+        )
+    # otherwise, it's a value
+    return {"==": expr}
+
+
+def validate_and_standardize_operators(expr: Dict) -> Dict:
+    std_expr = {}
+    for op, val in expr.items():
+        if op in OPERATOR_MAP:
+            std_expr[OPERATOR_MAP[op]] = val
+        else:
+            std_expr[op] = val
+    for op in std_expr:
+        if op not in VALID_OPERATORS:
+            raise ValueError(
+                f"Invalid operator: {op}. Operator must be one of: {VALID_OPERATORS}."
+            )
+    if "<" in std_expr and "<=" in std_expr:
+        raise ValueError(f"Either '<' or '<=' may be used in {expr}, not both.")
+    if ">" in std_expr and ">=" in std_expr:
+        raise ValueError(f"Either '>' or '>=' may be used in {expr}, not both.")
+    return std_expr
+
+
 def validate_query(
-    indices: Dict,
+    indexes: Dict,
     match: Optional[Dict[Union[str, Callable], Any]] = None,
     exclude: Optional[Dict[Union[str, Callable], Any]] = None,
 ):
@@ -43,14 +76,16 @@ def validate_query(
             if not isinstance(m, dict):
                 raise TypeError("Arguments must be of type dict or None.")
     # input validation -- check that we have an index for all desired lookups
-    required_indices = set()
+    required_indexes = set()
     if match:
-        required_indices.update(match.keys())
+        required_indexes.update(match.keys())
     if exclude:
-        required_indices.update(exclude.keys())
-    missing_indices = required_indices.difference(indices)
-    if missing_indices:
-        raise AttributeNotFoundError
+        required_indexes.update(exclude.keys())
+    missing_indexes = required_indexes.difference(indexes)
+    if missing_indexes:
+        raise AttributeNotFoundError(
+            f"Cannot find on: {list(missing_indexes)}. Atributes must be specified on creation."
+        )
 
 
 def make_empty_array(dtype: str):
@@ -68,16 +103,3 @@ def cyk_union(s1: Int64Set, s2: Int64Set) -> Int64Set:
     """Cykhash unions are faster on big.union(small); handle that appropriately.
     https://github.com/realead/cykhash/issues/7"""
     return s1.union(s2) if len(s1) > len(s2) else s2.union(s1)
-
-
-def fix_operators(expr: Dict):
-    # sanitizes input, mutates expr
-    for op in list(expr.keys()):
-        if op in OPERATOR_MAP:
-            val = expr.pop(op)
-            expr[OPERATOR_MAP[op]] = val
-    for op in expr:
-        if op not in VALID_OPERATORS:
-            raise ValueError(
-                f"Invalid operator: {op}. Operator must be one of: {VALID_OPERATORS}."
-            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "filterbox"
 version = "0.9.1"
-description = "Container for finding Python objects by matching attributes. Stores objects by attribute value for fast lookup."
+description = "Finds Python objects by attribute value"
 authors = ["Theo Walker <theo.ca.walker@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/manimino/filterbox/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "filterbox"
-version = "0.9.1"
+version = "0.9.2"
 description = "Finds Python objects by attribute value"
 authors = ["Theo Walker <theo.ca.walker@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "filterbox"
-version = "0.9.2"
+version = "0.9.3"
 description = "Finds Python objects by attribute value"
 authors = ["Theo Walker <theo.ca.walker@gmail.com>"]
 license = "MIT"

--- a/test/concurrent/test_multi_writer.py
+++ b/test/concurrent/test_multi_writer.py
@@ -31,8 +31,8 @@ def test_add_remove(priority, end_full, expected_len):
     box = ConcurrentFilterBox(objs, ["x"], priority=priority)
     # box = FilterBox(objs, ['x'])  # <--- use this instead, and you will observe frequent failures on this test.
 
-    # Patch indices 'add' to add a small delay, forcing race conditions to occur more often
-    box._indices["x"].add = slow_wrapper(box._indices["x"].add)
+    # Patch indexes 'add' to add a small delay, forcing race conditions to occur more often
+    box._indexes["x"].add = slow_wrapper(box._indexes["x"].add)
 
     duration = 0.2
     t0 = time.time()
@@ -48,4 +48,4 @@ def test_add_remove(priority, end_full, expected_len):
         t1.join()
         t2.join()
         assert len(box) == expected_len
-        assert len(box._indices["x"]) == expected_len  # fails on FilterBox
+        assert len(box._indexes["x"]) == expected_len  # fails on FilterBox

--- a/test/cov.txt
+++ b/test/cov.txt
@@ -2,22 +2,22 @@
 platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
 rootdir: /home/theo/repos
 plugins: anyio-2.2.0, cov-3.0.0
-collected 464 items
+collected 468 items
 
-test/test_basic_operations.py .......................................... [  9%]
+test/test_basic_operations.py .......................................... [  8%]
 ...........................                                              [ 14%]
 test/test_btree.py ..................................                    [ 22%]
 test/test_container_ops.py .....................                         [ 26%]
 test/test_edge_cases.py ......................................           [ 34%]
-test/test_examples.py ......                                             [ 36%]
+test/test_examples.py ......                                             [ 35%]
 test/test_exceptions.py ................                                 [ 39%]
-test/test_fancy_gets.py ............                                     [ 42%]
-test/test_missing_attribute.py ......................................... [ 51%]
-.                                                                        [ 51%]
-test/test_mixed_cardinality.py ..................                        [ 55%]
-test/test_mutations.py ...............                                   [ 58%]
-test/test_nones.py ...                                                   [ 59%]
-test/test_range_queries.py ............................................. [ 68%]
+test/test_fancy_gets.py ............                                     [ 41%]
+test/test_missing_attribute.py ......................................... [ 50%]
+.                                                                        [ 50%]
+test/test_mixed_cardinality.py ..................                        [ 54%]
+test/test_mutations.py ...............                                   [ 57%]
+test/test_nones.py .......                                               [ 59%]
+test/test_range_queries.py ............................................. [ 69%]
 ........................................................................ [ 84%]
 .................................                                        [ 91%]
 test/test_stale_objects.py ...........                                   [ 93%]
@@ -49,4 +49,4 @@ filterbox/utils.py                     50      0   100%
 TOTAL                                 619      0   100%
 
 
-============================= 464 passed in 6.70s ==============================
+============================= 468 passed in 6.78s ==============================

--- a/test/cov.txt
+++ b/test/cov.txt
@@ -1,6 +1,6 @@
 ============================= test session starts ==============================
 platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
-rootdir: /home/theo/repos
+rootdir: /home/theo/repos/filterbox
 plugins: anyio-2.2.0, cov-3.0.0
 collected 468 items
 
@@ -49,4 +49,4 @@ filterbox/utils.py                     50      0   100%
 TOTAL                                 619      0   100%
 
 
-============================= 468 passed in 6.78s ==============================
+============================= 468 passed in 5.69s ==============================

--- a/test/cov.txt
+++ b/test/cov.txt
@@ -1,21 +1,21 @@
 ============================= test session starts ==============================
 platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
-rootdir: /home/theo/repos/filterbox
+rootdir: /home/theo/repos
 plugins: anyio-2.2.0, cov-3.0.0
-collected 468 items
+collected 471 items
 
 test/test_basic_operations.py .......................................... [  8%]
 ...........................                                              [ 14%]
-test/test_btree.py ..................................                    [ 22%]
+test/test_btree.py ..................................                    [ 21%]
 test/test_container_ops.py .....................                         [ 26%]
 test/test_edge_cases.py ......................................           [ 34%]
 test/test_examples.py ......                                             [ 35%]
-test/test_exceptions.py ................                                 [ 39%]
-test/test_fancy_gets.py ............                                     [ 41%]
+test/test_exceptions.py ...................                              [ 39%]
+test/test_fancy_gets.py ............                                     [ 42%]
 test/test_missing_attribute.py ......................................... [ 50%]
-.                                                                        [ 50%]
+.                                                                        [ 51%]
 test/test_mixed_cardinality.py ..................                        [ 54%]
-test/test_mutations.py ...............                                   [ 57%]
+test/test_mutations.py ...............                                   [ 58%]
 test/test_nones.py .......                                               [ 59%]
 test/test_range_queries.py ............................................. [ 69%]
 ........................................................................ [ 84%]
@@ -30,23 +30,23 @@ test/mutable/test_soak.py .                                              [100%]
 Name                                Stmts   Miss  Cover
 -------------------------------------------------------
 filterbox/__init__.py                   5      0   100%
-filterbox/btree.py                     77      0   100%
+filterbox/btree.py                     76      0   100%
 filterbox/concurrent/__init__.py        0      0   100%
 filterbox/concurrent/main.py           51      0   100%
 filterbox/constants.py                 13      0   100%
 filterbox/exceptions.py                 3      0   100%
 filterbox/frozen/__init__.py            0      0   100%
-filterbox/frozen/froz_attr_val.py      95      0   100%
-filterbox/frozen/main.py               94      0   100%
+filterbox/frozen/froz_attr_val.py      97      0   100%
+filterbox/frozen/main.py               82      0   100%
 filterbox/frozen/utils.py               8      0   100%
 filterbox/init_helpers.py              22      0   100%
 filterbox/mutable/__init__.py           0      0   100%
-filterbox/mutable/main.py              97      0   100%
+filterbox/mutable/main.py              99      0   100%
 filterbox/mutable/mutable_attr.py     104      0   100%
 filterbox/perf.py                       0      0   100%
-filterbox/utils.py                     50      0   100%
+filterbox/utils.py                     64      0   100%
 -------------------------------------------------------
-TOTAL                                 619      0   100%
+TOTAL                                 624      0   100%
 
 
-============================= 468 passed in 5.69s ==============================
+============================= 471 passed in 6.61s ==============================

--- a/test/cov.txt
+++ b/test/cov.txt
@@ -1,6 +1,6 @@
 ============================= test session starts ==============================
 platform linux -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
-rootdir: /home/theo/repos/filterbox
+rootdir: /home/theo/repos
 plugins: anyio-2.2.0, cov-3.0.0
 collected 464 items
 
@@ -30,7 +30,7 @@ test/mutable/test_soak.py .                                              [100%]
 Name                                Stmts   Miss  Cover
 -------------------------------------------------------
 filterbox/__init__.py                   5      0   100%
-filterbox/btree.py                     80      0   100%
+filterbox/btree.py                     77      0   100%
 filterbox/concurrent/__init__.py        0      0   100%
 filterbox/concurrent/main.py           51      0   100%
 filterbox/constants.py                 13      0   100%
@@ -42,11 +42,11 @@ filterbox/frozen/utils.py               8      0   100%
 filterbox/init_helpers.py              22      0   100%
 filterbox/mutable/__init__.py           0      0   100%
 filterbox/mutable/main.py              97      0   100%
-filterbox/mutable/mutable_attr.py     103      0   100%
+filterbox/mutable/mutable_attr.py     104      0   100%
 filterbox/perf.py                       0      0   100%
 filterbox/utils.py                     50      0   100%
 -------------------------------------------------------
-TOTAL                                 621      0   100%
+TOTAL                                 619      0   100%
 
 
-============================= 464 passed in 5.63s ==============================
+============================= 464 passed in 6.70s ==============================

--- a/test/mutable/test_soak.py
+++ b/test/mutable/test_soak.py
@@ -147,12 +147,12 @@ class SoakTest:
         ]
         f_ls = self.f.find({"planet": "saturn"})
         assert len(ls) == len(f_ls)
-        assert len(self.objs) == len(self.f._indices["planet"])
+        assert len(self.objs) == len(self.f._indexes["planet"])
         # check a functional key
         ls = [o for o in self.objs.values() if get_attribute(o, planet_len)[0] == 6]
         f_ls = self.f.find({planet_len: 6})
         assert len(ls) == len(f_ls)
-        assert len(self.objs) == len(self.f._indices[planet_len])
+        assert len(self.objs) == len(self.f._indexes[planet_len])
         # check a null-ish key
         ls = [
             o for o in self.objs.values() if get_attribute(o, "sometimes")[1] == False
@@ -164,7 +164,7 @@ class SoakTest:
         ls = [o for o in self.objs.values() if get_attribute(o, "collider")[0] == c]
         f_ls = self.f.find({"collider": c})
         assert len(ls) == len(f_ls)
-        assert len(self.objs) == len(self.f._indices["collider"])
+        assert len(self.objs) == len(self.f._indexes["collider"])
         # check an object-ish key
         t = self.random_obj()
         if t is not None:

--- a/test/test_basic_operations.py
+++ b/test/test_basic_operations.py
@@ -44,13 +44,13 @@ def test_find_one(box_class):
 
 def test_find_union(box_class):
     f = make_test_filterbox(box_class)
-    result = f.find({"name": {"in": ["Pikachu", "Eevee"]}})
+    result = f.find({"name": ["Pikachu", "Eevee"]})
     assert len(result) == 3
 
 
 def test_find_union_with_mismatch(box_class):
     f = make_test_filterbox(box_class)
-    result = f.find({"name": {"in": ["Pikachu", "Shykadu"]}})
+    result = f.find({"name": ["Pikachu", "Shykadu"]})
     assert len(result) == 2
 
 

--- a/test/test_btree.py
+++ b/test/test_btree.py
@@ -100,10 +100,6 @@ def test_keys_values():
 
 def test_bad_expr():
     bt = BTree({"a": 1, "b": 2})
-    with AssertRaises(ValueError):
-        bt.get_range_expr({">": "a", ">=": "a"})
-    with AssertRaises(ValueError):
-        bt.get_range_expr({"<": "a", "<=": "a"})
     with AssertRaises(TypeError):
         bt.get_range_expr({"<=": 99})
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -61,3 +61,11 @@ def test_bad_operator(box_class):
     f = box_class(["ok"], on="x")
     with AssertRaises(ValueError):
         f.find({"x": {"qq": 2}})
+
+
+def test_bad_gt_lt(box_class):
+    f = box_class(["ok"], on="x")
+    with AssertRaises(ValueError):
+        f.find({"x": {">": 2, ">=": 3}})
+    with AssertRaises(ValueError):
+        f.find({"x": {"<": 2, "<=": 3}})

--- a/test/test_missing_attribute.py
+++ b/test/test_missing_attribute.py
@@ -20,7 +20,7 @@ def test_missing_function(box_class, n_items):
     assert len(fb) == n_items
     assert len(fb.find(match={even: True})) == n_even
     assert len(fb.find(exclude={even: True})) == n_odd
-    for idx in fb._indices.values():
+    for idx in fb._indexes.values():
         assert len(idx) == n_even
 
 
@@ -37,8 +37,8 @@ def test_add_with_missing_attributes():
     for d in missing_attr_data:
         fb.add(d)
     assert len(fb) == 4
-    assert len(fb._indices["a"]) == 2
-    assert len(fb._indices["b"]) == 2
+    assert len(fb._indexes["a"]) == 2
+    assert len(fb._indexes["b"]) == 2
     assert len(fb.find(exclude={"b": {"in": [2, 4]}})) == 2
     assert len(fb.find(exclude={"a": {"in": [1, 3]}})) == 2
 
@@ -48,7 +48,7 @@ def test_remove_with_missing_attributes():
     for d in missing_attr_data:
         fb.remove(d)
     assert len(fb) == 0
-    for idx in fb._indices.values():
+    for idx in fb._indexes.values():
         assert len(idx) == 0
 
 
@@ -56,8 +56,8 @@ def test_missing_attributes(box_class):
     fb = box_class(missing_attr_data, ["a", "b"])
     for d in missing_attr_data:
         assert d in fb
-    assert len(fb._indices["a"]) == 2
-    assert len(fb._indices["b"]) == 2
+    assert len(fb._indexes["a"]) == 2
+    assert len(fb._indexes["b"]) == 2
 
 
 def test_add_none():

--- a/test/test_multiple_operations.py
+++ b/test/test_multiple_operations.py
@@ -1,0 +1,23 @@
+
+def test_eq_and_greater(box_class):
+    objs = [{'x': i} for i in range(10)]
+    fb = box_class(objs, 'x')
+    assert fb.find({'x': {'==': 1, '>': 0}}) == [objs[1]]
+
+
+def test_eq_and_in(box_class):
+    objs = [{'x': i} for i in range(10)]
+    fb = box_class(objs, 'x')
+    assert fb.find({'x': {'eq': 1, 'in': [1, 2, 3]}}) == [objs[1]]
+
+
+def test_greater_less_and_in(box_class):
+    objs = [{'x': i} for i in range(10)]
+    fb = box_class(objs, 'x')
+    assert len(fb.find({'x': {'gt': 1, 'lt': 5, 'in': [1, 2, 3]}})) == 2
+
+
+def test_gte_lte_in_and_eq(box_class):
+    objs = [{'x': i} for i in range(10)]
+    fb = box_class(objs, 'x')
+    assert len(fb.find({'x': {'gte': 1, 'lte': 5, 'in': [1, 2, 3], 'eq': 2}})) == 1

--- a/test/test_nones.py
+++ b/test/test_nones.py
@@ -16,14 +16,16 @@ def test_none(box_class):
     assert len(fb.find({"ok": None})) == 1
 
 
-@pytest.mark.parametrize('n_none', [1, ARRAY_SIZE_MAX-1, ARRAY_SIZE_MAX+1, SET_SIZE_MIN])
+@pytest.mark.parametrize(
+    "n_none", [1, ARRAY_SIZE_MAX - 1, ARRAY_SIZE_MAX + 1, SET_SIZE_MIN]
+)
 def test_add_remove_none(n_none):
-    objs = [{'a': i} for i in range(10)]
+    objs = [{"a": i} for i in range(10)]
     for i in range(n_none):
-        objs.append({'a': None})
-    fb = FilterBox(objs, 'a')
-    assert len(fb.find({'a': {'in': [1, 2, None]}})) == 2 + n_none
-    assert len(fb.find({'a': {'in': [None]}})) == n_none
+        objs.append({"a": None})
+    fb = FilterBox(objs, "a")
+    assert len(fb.find({"a": {"in": [1, 2, None]}})) == 2 + n_none
+    assert len(fb.find({"a": {"in": [None]}})) == n_none
     fb.remove(objs[0])  # {'a': 0}
     fb.remove(objs[-1])  # {'a': None}
     assert len(fb) == len(objs) - 2

--- a/test/test_nones.py
+++ b/test/test_nones.py
@@ -4,9 +4,26 @@ to support it as it's a common attribute value.
 These tests check that None is handled properly.
 """
 
+import pytest
+from filterbox import FilterBox
+from filterbox.constants import SET_SIZE_MIN, ARRAY_SIZE_MAX
+
 
 def test_none(box_class):
     objs = [{"ok": i} for i in range(10)]
     objs.append({"ok": None})
     fb = box_class(objs, "ok")
     assert len(fb.find({"ok": None})) == 1
+
+
+@pytest.mark.parametrize('n_none', [1, ARRAY_SIZE_MAX-1, ARRAY_SIZE_MAX+1, SET_SIZE_MIN])
+def test_add_remove_none(n_none):
+    objs = [{'a': i} for i in range(10)]
+    for i in range(n_none):
+        objs.append({'a': None})
+    fb = FilterBox(objs, 'a')
+    assert len(fb.find({'a': {'in': [1, 2, None]}})) == 2 + n_none
+    assert len(fb.find({'a': {'in': [None]}})) == n_none
+    fb.remove(objs[0])  # {'a': 0}
+    fb.remove(objs[-1])  # {'a': None}
+    assert len(fb) == len(objs) - 2

--- a/test/test_range_queries.py
+++ b/test/test_range_queries.py
@@ -34,7 +34,8 @@ from filterbox.constants import SIZE_THRESH
     ],
 )
 def test_get_range_expr(box_class, expr, result):
-    fb = box_class([{"a": i} for i in range(10)], "a")
+    objs = [{"a": i} for i in range(10)] + [{'a': None}]
+    fb = box_class(objs, "a")
     assert list(sorted(o["a"] for o in fb.find({"a": expr}))) == result
 
 
@@ -70,9 +71,10 @@ def test_get_range_expr(box_class, expr, result):
 )
 def test_get_big(box_class, expr):
     objs = [{"a": i % 10} for i in range(SIZE_THRESH * 11)]
+    objs += [{"a": None} for _ in range(SIZE_THRESH + 1)]
     fb = box_class(objs, "a")
     found = fb.find({"a": expr})
-    result = objs
+    result = [o for o in objs if o['a'] is not None]
     for op, val in expr.items():
         if op == ">":
             result = [o for o in result if o["a"] > val]

--- a/test/test_range_queries.py
+++ b/test/test_range_queries.py
@@ -34,7 +34,7 @@ from filterbox.constants import SIZE_THRESH
     ],
 )
 def test_get_range_expr(box_class, expr, result):
-    objs = [{"a": i} for i in range(10)] + [{'a': None}]
+    objs = [{"a": i} for i in range(10)] + [{"a": None}]
     fb = box_class(objs, "a")
     assert list(sorted(o["a"] for o in fb.find({"a": expr}))) == result
 
@@ -74,7 +74,7 @@ def test_get_big(box_class, expr):
     objs += [{"a": None} for _ in range(SIZE_THRESH + 1)]
     fb = box_class(objs, "a")
     found = fb.find({"a": expr})
-    result = [o for o in objs if o['a'] is not None]
+    result = [o for o in objs if o["a"] is not None]
     for op, val in expr.items():
         if op == ">":
             result = [o for o in result if o["a"] > val]

--- a/test/test_stale_objects.py
+++ b/test/test_stale_objects.py
@@ -25,7 +25,7 @@ def test_remove_stale_objects(n_items):
     for o in objs:
         f.remove(o)
     assert len(f) == 0
-    assert len(f._indices["z"]) == 0
+    assert len(f._indexes["z"]) == 0
 
 
 @pytest.mark.parametrize("n_items", [1, 5, SIZE_THRESH * 2 + 2])

--- a/test/test_wrong_type.py
+++ b/test/test_wrong_type.py
@@ -43,6 +43,6 @@ def test_find_wrong_type(box_class, expr, expected, raises):
 def test_add_wrong_type():
     objs = [{"x": i} for i in range(10)]
     fb = FilterBox(objs, "x")
-    assert len(fb._indices["x"].tree) == 10
+    assert len(fb._indexes["x"].tree) == 10
     with AssertRaises(TypeError):
         fb.add({"x": "lol"})

--- a/test/test_wrong_type.py
+++ b/test/test_wrong_type.py
@@ -32,7 +32,6 @@ def test_find_wrong_type(box_class, expr, expected, raises):
         expr = {"in": expr}
     objs = [{"x": i} for i in range(10)]
     fb = box_class(objs, "x")
-    print("raises", raises)
     if raises:
         with AssertRaises(TypeError):
             fb.find({"x": expr})


### PR DESCRIPTION
- Several small refactor / cleanups, consolidating copied code
- Many docs updates to reflect BTree changes
- Added `{'x': [1,2,3]}` syntax back in, as a shorthand for `{'x': {'in': [1,2,3]}}` 
- `{'x': {'eq': 1}}` is now a thing. So now all operations can be expressed in an expr dict. Just for consistency.
- Examples were broken, now they are not

In the next episode:
- Why Not SQLite section probably needs a second draft
- Need save and load functions, because pickle will not work on them, not even Frozen. Saved `id()`s are the problem. Easy to fix.